### PR TITLE
chore: fix typo in social links

### DIFF
--- a/src/components/atoms/social-link.astro
+++ b/src/components/atoms/social-link.astro
@@ -15,7 +15,7 @@ const { href, icon, ariaLabel } = Astro.props as Props;
     href={href}
     aria-label={ariaLabel}
     target='_blank'
-    rel='noreferrer noopner'
+    rel='noreferrer noopener'
   >
     <Icon name={icon} />
   </a>


### PR DESCRIPTION
Change 'noopner' -> 'noopener'